### PR TITLE
Add possibility to define panels labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ public function boot()
 }
 ```
 
+#### Labels
+You have the ability to set personalized labels for your panels by utilizing the `labels()` method. This feature can also be employed for translation purposes.
+
+```php
+PanelSwitch::configureUsing(function (PanelSwitch $panelSwitch) {
+    $panelSwitch
+        ->labels([
+            'admin' => 'Custom Admin Label',
+            'general_manager' => __('General Manager')
+        ]);
+});
+```
+
 #### Visibility
 By default, the package checks whether the user can access the panel if so the switch will be visible. You can further customize whether the panel switch should be shown.
 

--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -9,7 +9,7 @@
             class="group flex w-full items-center justify-center gap-x-3 rounded-lg shadow-sm p-2 text-sm font-medium outline-none bg-primary-500"
         >
             <span class="shrink-0 font-semibold rounded-full w-5 h-5 bg-white text-primary-500">
-                P
+                {{str($labels[$currentPanel->getId()] ?? $currentPanel->getId())->substr(0, 1)->upper()}}
             </span>
             <span class="text-white">
                 {{ $labels[$currentPanel->getId()] ?? str($currentPanel->getId())->ucfirst() }}
@@ -28,7 +28,7 @@
         @foreach ($panels as $panel)
             <x-filament::dropdown.list.item
                 :href="$canSwitchPanels && $panel->getId() !== $currentPanel->getId() ? config('app.url').'/'.$panel->getPath() : null"
-                :badge="str($panel->getId())->substr(0, 2)->upper()"
+                :badge="str($labels[$panel->getId()] ?? $panel->getId())->substr(0, 2)->upper()"
                 tag="a"
             >
                 {{ $labels[$panel->getId()] ?? str($panel->getId())->ucfirst() }}

--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -31,7 +31,7 @@
                 :badge="str($panel->getId())->substr(0, 2)->upper()"
                 tag="a"
             >
-                {{ $labels[$currentPanel->getId()] ?? str($currentPanel->getId())->ucfirst() }}
+                {{ $labels[$panel->getId()] ?? str($panel->getId())->ucfirst() }}
             </x-filament::dropdown.list.item>
         @endforeach
     </x-filament::dropdown.list>

--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -12,7 +12,7 @@
                 P
             </span>
             <span class="text-white">
-                {{ str($currentPanel->getId())->ucfirst() }}
+                {{ $labels[$currentPanel->getId()] ?? str($currentPanel->getId())->ucfirst() }}
             </span>
 
             <x-filament::icon
@@ -31,7 +31,7 @@
                 :badge="str($panel->getId())->substr(0, 2)->upper()"
                 tag="a"
             >
-                {{ str($panel->getId())->ucfirst() }}
+                {{ $labels[$currentPanel->getId()] ?? str($currentPanel->getId())->ucfirst() }}
             </x-filament::dropdown.list.item>
         @endforeach
     </x-filament::dropdown.list>

--- a/src/PanelSwitch.php
+++ b/src/PanelSwitch.php
@@ -15,6 +15,8 @@ class PanelSwitch
 
     protected array $excludes = [];
 
+    protected array $labels = [];
+
     protected bool | Closure | null $visible = null;
 
     protected bool | Closure | null $canSwitchPanel = true;
@@ -55,6 +57,7 @@ class PanelSwitch
 
                 return view('filament-panel-switch::panel-switch-menu', [
                     'panels' => $static->getPanels(),
+                    'labels' => $static->getLabels(),
                     'currentPanel' => $static->getCurrentPanel(),
                     'canSwitchPanels' => $static->isAbleToSwitchPanels(),
                 ]);
@@ -67,6 +70,18 @@ class PanelSwitch
         $this->excludes = $panelIds;
 
         return $this;
+    }
+
+    public function labels(array $labels): static
+    {
+        $this->labels = $labels;
+
+        return $this;
+    }
+
+    public function getLabels(): array
+    {
+        return $this->labels;
     }
 
     public function getExcludes(): array


### PR DESCRIPTION
This pull request makes it easier to label panels by letting you use an array of `panel_id => label` pairs. This way, you can pick any label you prefer and even use translations if needed. It's a user-friendly improvement that adds more flexibility to working with panels.

e.g.
```php
PanelSwitch::configureUsing(function (PanelSwitch $panelSwitch) {
    $panelSwitch->renderHook('panels::global-search.before')
        ->labels([
             'admin' => 'Custom Label',
             'customer' => __('Cliente'),
        ]);
    });
```