### PR TITLE
Keep the URLs relative

### DIFF
--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -23,7 +23,7 @@
         <x-filament::dropdown.list>
             @foreach ($panels as $panel)
                 <x-filament::dropdown.list.item
-                    :href="$canSwitchPanels && $panel->getId() !== $currentPanel->getId() ? config('app.url') . '/' . $panel->getPath() : null"
+                    :href="$canSwitchPanels && $panel->getId() !== $currentPanel->getId() ? '/' . $panel->getPath() : null"
                     :badge="str($labels[$panel->getId()] ?? $panel->getId())->substr(0, 2)->upper()"
                     tag="a"
                 >
@@ -66,7 +66,7 @@
         >
             @foreach ($panels as $panel)
                 <a
-                    href="{{ $canSwitchPanels && $panel->getId() !== $currentPanel->getId() ? config('app.url') . '/' . $panel->getPath() : '#' }}"
+                    href="{{ $canSwitchPanels && $panel->getId() !== $currentPanel->getId() ? '/' . $panel->getPath() : '#' }}"
                     class="flex flex-col items-center justify-center flex-1 hover:cursor-pointer group panel-switch-card"
                 >
                     <div


### PR DESCRIPTION
Make the URL relative so that the switcher works with multi-tenant applications that have different subdomains per tenant.