### PR TITLE
Fix: Modal Trigger Issue with Top Navigation Enabled

### DIFF
--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -52,6 +52,7 @@
         }
     </style>
     <x-filament::icon-button
+        x-data="{}"
         icon="heroicon-s-square-2-stack"
         icon-alias="panels::panel-switch-modern-icon"
         icon-size="lg"
@@ -66,12 +67,11 @@
         :width="$modalWidth"
         alignment="center"
         :slide-over="$isSlideOver"
+        :sticky-header="$isSlideOver"
+        :heading="$heading"
+        display-classes="block"
         class="panel-switch-modal"
     >
-        <x-slot name="heading">
-            {{ $heading }}
-        </x-slot>
-
         <div
             class="flex flex-wrap items-center justify-center gap-4 md:gap-6"
         >


### PR DESCRIPTION
This commit addresses a critical issue where modals were not properly triggering or opening when top navigation was enabled in the application. For some reason, when top navigation is enabled, the icon button which triggers the modal needed to be reinitialized using alpine's `x-data` attribute. Users experiencing difficulty in interacting with modals in this scenario should now find the functionality working as expected.

Additionally, I have implemented a sticky header for modals when in slide-over mode. This improves the design of the header in the slide-over.

### Video

[PanelSwitch](https://github.com/bezhanSalleh/filament-panel-switch/assets/104294090/b9d53a14-efd2-43ab-8e65-be02cecf56a5)


