### PR TITLE
Use Filament Panel Urls

### DIFF
--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -1,5 +1,12 @@
 @php
-    $getPanelPath = fn (\Filament\Panel $panel): string => $panel->getHomeUrl() ?? $panel->getUrl();
+    $getPanelPath = function (\Filament\Panel $panel): string {
+        $filament = app('filament');
+        $currentPanel = $filament->getCurrentPanel();
+        $filament->setCurrentPanel($panel);
+        $url = $panel->getUrl();
+        $filament->setCurrentPanel($currentPanel);
+        return $url;
+    };
 
     $getHref = fn (\Filament\Panel $panel): ?string => $canSwitchPanels && $panel->getId() !== $currentPanel->getId()
             ? $getPanelPath($panel)

--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -8,9 +8,8 @@
         return $url;
     };
 
-    $getHref = fn (\Filament\Panel $panel): ?string => $canSwitchPanels && $panel->getId() !== $currentPanel->getId()
-            ? $getPanelPath($panel)
-            : null;
+    $getHref = fn(\Filament\Panel $panel): ?string => $canSwitchPanels ? $getPanelPath($panel) : null;
+
 @endphp
 
 @if ($isSimple)

--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -1,9 +1,5 @@
 @php
-    $getUrlScheme = (string) app()->environment('production') ? 'https://' : 'http://';
-
-    $getPanelPath = fn (\Filament\Panel $panel): string => filled($domains = $panel->getDomains())
-            ? str(collect($domains)->first())->prepend($getUrlScheme)->toString()
-            : str($panel->getPath())->prepend('/')->toString();
+    $getPanelPath = fn (\Filament\Panel $panel): string => $panel->getHomeUrl() ?? $panel->getUrl();
 
     $getHref = fn (\Filament\Panel $panel): ?string => $canSwitchPanels && $panel->getId() !== $currentPanel->getId()
             ? $getPanelPath($panel)


### PR DESCRIPTION
Currently, panel urls are not resolved correctly when they define both a path and a domain. Also the handling of http vs https is hardcoded. This uses Filament's panel home url or panel url which will generate the correct url with scheme, domain and path.