### PR TITLE
fix: Add `null` as return type to match `$panel->getUrl()`

### DIFF
--- a/resources/views/panel-switch-menu.blade.php
+++ b/resources/views/panel-switch-menu.blade.php
@@ -1,5 +1,5 @@
 @php
-    $getPanelPath = function (\Filament\Panel $panel): string {
+    $getPanelPath = function (\Filament\Panel $panel): ?string {
         $filament = app('filament');
         $currentPanel = $filament->getCurrentPanel();
         $filament->setCurrentPanel($panel);


### PR DESCRIPTION
This PR fix the return type of the function in `panel-switch-menu.blade.php` to match the return type in `$panel->getUrl()` as it can get issues.