### PR TITLE
Fix: Custom panel domains does not work.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "league/uri": "^7.5",
+        "league/uri": "^7",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
+        "league/uri": "^7.5",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/src/PanelSwitch.php
+++ b/src/PanelSwitch.php
@@ -7,6 +7,8 @@ use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Components\Component;
 use Filament\Support\Facades\FilamentView;
+use Illuminate\Support\Arr;
+use League\Uri\Uri;
 
 class PanelSwitch extends Component
 {
@@ -285,12 +287,20 @@ class PanelSwitch extends Component
                 },
                 default: fn ($panelCollection) => $panelCollection
             )
-            ->mapWithKeys(fn (Panel $panel) => [$panel->getId() => $this->isAbleToSwitchPanels() ? url($panel->getPath()) : null])
+            ->mapWithKeys(fn (Panel $panel) => [$panel->getId() => $this->isAbleToSwitchPanels() ? $this->getPanelUrl($panel) : null])
             ->when(
                 value: filled($this->getSortOrder()),
                 callback: fn ($panelCollection) => $panelCollection->sortKeys(descending: $this->getSortOrder() === 'desc')
             )
             ->toArray();
+    }
+
+    protected function getPanelUrl(Panel $panel)
+    {
+        return Uri::new()
+           ->withPath('/'.$panel->getPath())
+           ->withHost(Arr::first($panel->getDomains()))
+           ->toString();
     }
 
     public function getCurrentPanel(): Panel


### PR DESCRIPTION
The current implementation does not work if you use custom domains for you different panels. It only uses the path you specify in your panel provider. 

For example:

```php
// Panel 1
class AdminPanelProvider extends PanelProvider
{
    public function panel(Panel $panel): Panel
    {
        return $panel
            ->default()
            //...
            ->path('')
            ->domains(['app.'.config('app.domain')]);
    }
}

// Panel 2
class AdminPanelProvider extends PanelProvider
{
    public function panel(Panel $panel): Panel
    {
        return $panel
            ->default()
            //...
            ->path('')
            ->domains(['admin.'.config('app.domain')]);
    }
}
```

It might seem unnecessary to include a package for this, but this package is already included in Laravel 11.35+ so it should only be an extra dependency for projects that uses older versions of Laravel. This was better than to use the URL helper that shipps with Laravel 11.35+ as you would than have to require Laravel 11.35+.