### PR TITLE
Fix bug where path starts with /

### DIFF
--- a/src/PanelSwitch.php
+++ b/src/PanelSwitch.php
@@ -298,7 +298,7 @@ class PanelSwitch extends Component
     protected function getPanelUrl(Panel $panel)
     {
         return Uri::new()
-            ->withPath('/' . $panel->getPath())
+            ->withPath('/' . ltrim($panel->getPath()), '/')
             ->withHost(Arr::first($panel->getDomains()))
             ->toString();
     }


### PR DESCRIPTION
Haven't tested this much, but it should solve issue #43 

Any leading `/` will now be trimmed from the path.

