### PR TITLE
null safe

### DIFF
--- a/src/PanelSwitch.php
+++ b/src/PanelSwitch.php
@@ -249,7 +249,7 @@ class PanelSwitch extends Component
                     $withDefaultOrder = $panelCollection->only($panelIds);
 
                     return collect($panelIds)
-                        ->map(fn (string $id) => $withDefaultOrder[$id])
+                        ->map(fn (string $id) => $withDefaultOrder[$id] ?? null)
                         ->filter();
                 },
                 default: fn ($panelCollection) => $panelCollection


### PR DESCRIPTION
There are some configuration where `PanelSwitch` can be configured for panels for which a user does not have access in these cases we can get "undefined array key <panel id>"

This PR fixes this edge case by allowing `panelIds` which exist but the user doesnt have access to with a simple nullsafe

The use case for the configuration can be when you have 3 panels and only want `PanelSwitch` on 2 of them and only for the users who can access both e.g. 1 can be a "global" panel where all users can access, 2 can be limited to a subset of users, 3 might be an admin panel, `PanelSwitch` might be configured for panels 2 and 3 and would work for admins but break for users who can only access panel 2 (everyone can access panel 1 but we dont want it in the panel switcher)

currently `$panelSwitch->panels()` assumes we are limiting  `PanelSwitch` to a subset of panels the user has access to but breaks when there are panels included that the user cant access